### PR TITLE
Fix multiline quote detection

### DIFF
--- a/scripts/parse_full_and_diff_cleaned.py
+++ b/scripts/parse_full_and_diff_cleaned.py
@@ -38,7 +38,7 @@ def strip_multiline_comments(lines):
 
     for line in lines:
         # Start or end of multi-line block
-        if not in_block and (line.strip().startswith('"""') or line.strip().startswith(''''')):
+        if not in_block and (line.strip().startswith('"""') or line.strip().startswith("'''")):
             in_block = True
             block_delimiter = line.strip()[:3] # Store block_delimiter
             # If its a single line docstring, skip it entirely


### PR DESCRIPTION
## Summary
- fix detection of triple-quoted comment blocks

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d89a69288329891615d8dec73029